### PR TITLE
Python 3 standard

### DIFF
--- a/moodbot/Dockerfile
+++ b/moodbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:3.6-slim
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
If there is nothing that we explicitly need python 2 for, we should make python 3 the standard for our docker builds, since non-latin alphabet languages create a lot of problems for python 2's quirky byte/str/unicode handling